### PR TITLE
Added poppins-mocks for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .cache
 config.js
 config-credentials.js
+.idea
+node_modules

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   "devDependencies": {
     "mocha": "~1.12.0",
     "should": "~1.2.2",
-    "rewire": "~1.1.3"
+    "rewire": "~1.1.3",
+    "expect.js": "~0.2.0",
+    "supertest": "~0.8.2",
+    "nock": "0.25.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha tests/"
   },
   "repository": {
     "type": "git",

--- a/poppins-mocks.js
+++ b/poppins-mocks.js
@@ -1,0 +1,162 @@
+// see https://github.com/visionmedia/superagent
+var request = require('supertest');
+// see https://github.com/pgte/nock
+var nock = require('nock');
+
+var Q = require('q');
+Q.longStackSupport = true;
+
+var expect = require('expect.js');
+var Poppins = require('./poppins.js').Poppins;
+var debugging = false;
+
+
+beforeEach(function() {
+  nock.cleanAll();
+});
+
+afterEach(function() {
+  closePoppins();
+});
+
+var exports = module.exports = {
+  poppins: null,
+  debug: debug,
+  createPoppins: createPoppins,
+  github: {
+    mock: githubMock,
+    mockGet: githubMockGet,
+    repoPath: repoPath,
+    issuesPath: issuesPath
+  },
+  request: poppinsRequest
+};
+
+function debug() {
+  debugging = true;
+  // can't turned off right now :-(
+  nock.recorder.rec();
+}
+
+function createPoppins(initData) {
+  closePoppins();
+  initData = initData || {};
+  initData.openIssues = initData.openIssues || [];
+  initData.closedIssues = initData.closedIssues || [];
+
+  var nockScopes = [];
+  nockScopes.push(githubMockGet(repoPath(), initData.repo || {
+    "id": 460078
+  }));
+  nockScopes.push(githubMockGet(issuesPath({state: 'open'}), initData.openIssues));
+  if (initData.openIssues.length) {
+    // if we have issues, poppins will ask for the next page
+    nockScopes.push(githubMockGet(issuesPath({state: 'open'}), []));
+  }
+  nockScopes.push(githubMockGet(issuesPath({state: 'closed'}), initData.closedIssues));
+  if (initData.closedIssues.length) {
+    // if we have issues, poppins will ask for the next page
+    nockScopes.push(githubMockGet(issuesPath({state: 'closed'}), []));
+  }
+
+  var poppins = exports.poppins = new Poppins({
+    target: {
+      user: 'someGithubUser',
+      repo: 'someGithubRepo'
+    },
+    login: {
+      username: 'someUser',
+      password: 'somePassword'
+    },
+    // port for poppins to listen on and URL for Github to ping
+    hook: {
+      url: 'http://example.com:1234',
+      port: 1234
+    }
+  });
+  clearPoppinsCache(poppins);
+
+  if (debugging) {
+    poppins.on('log', function(msg) {
+      console.log(msg);
+    });
+  }
+
+  return poppins.start().then(function() {
+    // assert that the repo, the open and closed issues were read.
+    // Then the corresponding mocks also have been removed.
+    nockScopes.forEach(function(nockScope) {
+      nockScope.done();
+    });
+  });
+
+}
+
+function closePoppins() {
+  if (exports.poppins) {
+    exports.poppins.stop();
+    exports.poppins = null;
+  }
+}
+
+function clearPoppinsCache(poppins) {
+  if (poppins.cache.exists('repo')) {
+    poppins.cache.clear('repo');
+  }
+  if (poppins.cache.exists('issues')) {
+    poppins.cache.clear('issues');
+  }
+  if (poppins.cache.exists('hook')) {
+    poppins.cache.clear('hook');
+  }
+}
+
+function githubMock(pathRegexStr) {
+  // using string regex so we don't have to escape
+  // slashes when defining them.
+  var pathRegex = new RegExp(pathRegexStr);
+  return nock('https://api.github.com:443')
+    .filteringPath(function(path) {
+      if (pathRegex.test(path)) {
+        return '/path';
+      } else {
+        return '/notMatched'
+      }
+    });
+}
+
+function githubMockGet(pathRegEx, response) {
+  return githubMock(pathRegEx)
+    .get('/path')
+    .reply(200, JSON.stringify(response),
+    { 'content-type': 'application/json; charset=utf-8',
+      status: '200 OK'
+    });
+}
+
+function repoPath() {
+  return '/repos/[^/]+/[^/]+$';
+}
+
+function issuesPath(filters) {
+  var res = '/issues', prop;
+  for (prop in filters) {
+    res += '.*'+prop+'='+filters[prop];
+  }
+  return res;
+}
+
+function poppinsRequest(data, callback) {
+  var deferred = Q.defer();
+
+  request(exports.poppins.server).post('/')
+    .send({
+      payload: JSON.stringify(data)
+    })
+    .type('application/json')
+    .set('Accept', 'application/json')
+    .expect(202)
+    .end(deferred.makeNodeResolver());
+
+  return deferred.promise;
+}

--- a/tests/basic-functionality-spec.js
+++ b/tests/basic-functionality-spec.js
@@ -1,0 +1,67 @@
+var mocks = require('../poppins-mocks.js');
+var expect = require('expect.js');
+
+// For debug logs: mocks.debug();
+
+describe('basic', function () {
+  it('should read the repo on startup', function(done) {
+    mocks.createPoppins({
+      repo: {
+        id: 123,
+        name: 'someName'
+      }
+    }).then(function() {
+      expect(mocks.poppins.repo).to.eql({
+          id: 123,
+          name: 'someName',
+          meta: {status: '200 OK'}
+      });
+    }).then(done, done);
+  });
+
+  it('should read the open issues on startup', function(done) {
+    mocks.createPoppins({
+      openIssues: [
+        { number: 123 }
+      ],
+      log: false
+    }).then(function() {
+      expect(mocks.poppins.issues).to.eql({
+        123: {
+          number: 123, comments: []
+        }
+      });
+    }).then(done, done);
+  });
+
+  it('should read the closed issues on startup', function(done) {
+    mocks.createPoppins({
+      closedIssues: [
+        { number: 123 }
+      ],
+      log: false
+    }).then(function() {
+        expect(mocks.poppins.issues).to.eql({
+          123: {
+            number: 123, comments: []
+          }
+        });
+      }).then(done, done);
+  });
+
+  it('should add an issue to its data when Github pushes it', function(done) {
+    mocks.createPoppins({
+      log: true
+    }).then(function() {
+      return mocks.request({
+          action: 'opened',
+          issue: {
+            number: 123
+          }
+        });
+    }).then(function(res){
+        expect(mocks.poppins.issues[123].number).to.be(123);
+        done();
+    });
+  });
+});


### PR DESCRIPTION
Mocks requests to Github and allows to send requests to
Mary Poppins easily. See `tests/basic-functionality-spec.js`
 for samples on how to use it.

 Requires a change to `metahub`:
 https://github.com/btford/metahub/pull/4
